### PR TITLE
Added Target branch name setting

### DIFF
--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -78,6 +78,10 @@ async function populateBranchAndPrProps(props: { [key: string]: string }) {
       defaultBranch = 'trunk';
     }
 
+    if (tl.getInput('targetBranchName')) {
+      defaultBranch = tl.getInput('targetBranchName');
+    }
+
     const currentBranch = tl.getVariable('Build.SourceBranch');
     if (currentBranch === defaultBranch) {
       props['sonar.branch.name'] = branchName(currentBranch);

--- a/extensions/codescancloud/tasks/prepare/new/task.json
+++ b/extensions/codescancloud/tasks/prepare/new/task.json
@@ -129,6 +129,13 @@
       "visibleRule": "scannerMode = MSBuild"
     },
     {
+      "name": "targetBranchName",
+      "type": "string",
+      "label": "Target branch name",
+      "defaultValue": "master",
+      "helpMarkDown": "Specify the target branch name, for example: ```develop```, otherwise the default repo branch will be used."
+    },
+    {
       "name": "cliSources",
       "type": "filePath",
       "label": "Sources directory root",

--- a/extensions/codescancloud/vss-extension.json
+++ b/extensions/codescancloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "codescan",
   "name": "CodeScan Cloud",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"
@@ -16,7 +16,7 @@
   "description":
     "Use the CodeScan build tasks in your build/release definitions to track bugs, code smells and vulnerabilities in Salesforce languages like Apex, VisualForce, Lightning, etc",
   "public": true,
-  "categories": ["Build and release"],
+  "categories": ["Azure Pipelines"],
   "icons": {
     "default": "extension-icon.png"
   },


### PR DESCRIPTION
Added new input field on "Prepare analysis on CodeScan Cloud" task to specify the exact branch name instead of using the default repo branch.

![image](https://user-images.githubusercontent.com/556093/88000148-a44ce800-cb05-11ea-96d0-b96167d485a3.png)
